### PR TITLE
Improve habit suggestion styling in MessageView

### DIFF
--- a/Features/Chat/MessageView.swift
+++ b/Features/Chat/MessageView.swift
@@ -22,21 +22,32 @@ struct MessageView: View {
                     .foregroundStyle(.primary)
 
                 if let list = message.habitSuggestion, !list.isEmpty {
-                    VStack(alignment: .leading, spacing: 6) {
+                    VStack(alignment: .leading, spacing: 8) {
                         ForEach(Array(list.enumerated()), id: \.offset) { _, item in
-                            HStack(alignment: .top, spacing: 8) {
-                                Image(systemName: "circle.fill")
-                                    .font(.system(size: 6))
-                                    .foregroundStyle(.secondary)
-                                    .padding(.top, 6)
+                            HStack(alignment: .center, spacing: 10) {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .font(.system(size: 16, weight: .semibold))
+                                    .foregroundStyle(Color.accentColor)
+
                                 Text(item)
-                                    .font(.system(size: 15))
-                                    .foregroundStyle(.secondary)
+                                    .font(.system(size: 15, weight: .medium))
+                                    .foregroundStyle(.primary)
+                                    .multilineTextAlignment(.leading)
                                     .fixedSize(horizontal: false, vertical: true)
                             }
+                            .padding(.vertical, 10)
+                            .padding(.horizontal, 12)
+                            .background(
+                                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                    .fill(.ultraThinMaterial)
+                            )
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                    .stroke(Color.white.opacity(0.2), lineWidth: 1)
+                            )
                         }
                     }
-                    .padding(.top, 2)
+                    .padding(.top, 4)
                 }
             }
             .padding(.vertical, 10)


### PR DESCRIPTION
## Summary
- replace the bullet list habit suggestions with individual rounded cards that include a checkmark icon
- update typography and spacing in the habit suggestion list to better align with the chat bubble styling

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d8ef99c66883218dc6a3058d3855a5